### PR TITLE
setter eksplisitt okhttp3 versjon

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ def overrides = [
     scriptVersion  : 'v7',
     iqOrganizationName: "Team AOS",
     iqBreakOnUnstable: true,
+    iqEmbedded: true,
     pipelineScript: 'https://git.aurora.skead.no/scm/ao/aurora-pipeline-scripts.git',
     credentialsId: "github",
     checkstyle : false,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,10 @@ dependencies {
     implementation("io.projectreactor.kotlin:reactor-kotlin-extensions:1.1.5")
     testImplementation("com.github.fkorotkov:k8s-kotlin-dsl:3.0.1")
 
+    /* explicit okhttp3 dependencies to force transitive */
+    implementation("com.squareup.okhttp3:okhttp:4.9.3")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.9.2")
+
     implementation("org.springframework.boot:spring-boot-starter-security")
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.springframework.boot:spring-boot-starter-test")


### PR DESCRIPTION
transitive okhttp3 dependencies ble nedgradert til versjon med CVE. Setter dependenciene eksplisitt for å tvinge versjon.